### PR TITLE
fix: Correct Strapi API endpoint for blog

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -207,7 +207,7 @@
             }
 
             try {
-                const response = await fetch(`${STRAPI_URL}/api/blogs/${postId}?populate=*`, {
+                const response = await fetch(`${STRAPI_URL}/api/articles/${postId}?populate=*`, {
                     headers: { 'Authorization': `Bearer ${STRAPI_API_TOKEN}` }
                 });
 

--- a/blog.html
+++ b/blog.html
@@ -237,7 +237,7 @@
         const fetchPosts = async () => {
             try {
                 // Fetch posts, sorting by publication date descending, and populating relations
-                const response = await fetch(`${STRAPI_URL}/api/blogs?sort=publishedAt:desc&populate=*`, {
+                const response = await fetch(`${STRAPI_URL}/api/articles?sort=publishedAt:desc&populate=*`, {
                     headers: { 'Authorization': `Bearer ${STRAPI_API_TOKEN}` }
                 });
 


### PR DESCRIPTION
- Updated the API endpoint from `/api/blogs` to `/api/articles` in both `blog.html` and `blog-post.html` as per user feedback.